### PR TITLE
Converted PLUGINLIB_DECLARE_CLASS to PLUGINLIB_EXPORT_CLASS

### DIFF
--- a/chomp/ros/chomp_interface_ros/src/chomp_plugin.cpp
+++ b/chomp/ros/chomp_interface_ros/src/chomp_plugin.cpp
@@ -106,6 +106,5 @@ private:
 
 } // ompl_interface_ros
 
-PLUGINLIB_DECLARE_CLASS(chomp_interface_ros, CHOMPPlanner,
-                        chomp_interface_ros::CHOMPPlanner, 
-                        planning_interface::Planner);
+PLUGINLIB_EXPORT_CLASS( chomp_interface_ros::CHOMPPlanner, planning_interface::Planner);
+                      

--- a/sbpl/ros/sbpl_interface_ros/src/sbpl_meta_plugin.cpp
+++ b/sbpl/ros/sbpl_interface_ros/src/sbpl_meta_plugin.cpp
@@ -112,6 +112,4 @@ private:
 
 } // ompl_interface_ros
 
-PLUGINLIB_DECLARE_CLASS(sbpl_interface_ros, SBPLMetaPlanner,
-                        sbpl_interface_ros::SBPLMetaPlanner, 
-                        planning_interface::Planner);
+PLUGINLIB_EXPORT_CLASS( sbpl_interface_ros::SBPLMetaPlanner, planning_interface::Planner);

--- a/sbpl/ros/sbpl_interface_ros/src/sbpl_plugin.cpp
+++ b/sbpl/ros/sbpl_interface_ros/src/sbpl_plugin.cpp
@@ -119,6 +119,4 @@ private:
 
 } // ompl_interface_ros
 
-PLUGINLIB_DECLARE_CLASS(sbpl_interface_ros, SBPLPlanner,
-                        sbpl_interface_ros::SBPLPlanner, 
-                        planning_interface::Planner);
+PLUGINLIB_EXPORT_CLASS( sbpl_interface_ros::SBPLPlanner, planning_interface::Planner);


### PR DESCRIPTION
to remove depreciated warnings
