### PR TITLE
Added ability to change planner configurations in the interface

### DIFF
--- a/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -97,9 +97,14 @@ public:
     return spec_;
   }
 
-  std::map<std::string, std::string>& getSpecificationConfig()
+  const std::map<std::string, std::string>& getSpecificationConfig() const
   {
     return spec_.config_;
+  }
+
+  void setSpecificationConfig(const std::map<std::string, std::string>& config)
+  {
+    spec_.config_ = config;
   }
 
   const robot_model::RobotModelConstPtr& getRobotModel() const

--- a/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -97,6 +97,11 @@ public:
     return spec_;
   }
 
+  std::map<std::string, std::string>& getSpecificationConfig()
+  {
+    return spec_.config_;
+  }
+
   const robot_model::RobotModelConstPtr& getRobotModel() const
   {
     return spec_.state_space_->getRobotModel();

--- a/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -61,9 +61,16 @@ public:
   
   /** @brief Specify configurations for the planners.
       @param pconfig Configurations for the different planners */
-  void setPlanningConfigurations(const std::vector<PlanningConfigurationSettings> &pconfig)
+  void setPlanningConfigurations(const PlanningConfigurationMap &pconfig)
   {
     context_manager_.setPlanningConfigurations(pconfig);
+  }
+
+  /** @brief Get the configurations for the planners that are already loaded
+      @param pconfig Configurations for the different planners */
+  const PlanningConfigurationMap& getPlanningConfigurations()
+  {
+    return context_manager_.getPlanningConfigurations();
   }
   
   /** @brief Solve the planning problem */

--- a/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -55,6 +55,7 @@ struct PlanningConfigurationSettings
   std::string                        group;
   std::map<std::string, std::string> config;
 };
+typedef std::map<std::string, PlanningConfigurationSettings> PlanningConfigurationMap;
 
 class PlanningContextManager
 {
@@ -65,7 +66,7 @@ public:
   
   /** @brief Specify configurations for the planners.
       @param pconfig Configurations for the different planners */
-  void setPlanningConfigurations(const std::vector<PlanningConfigurationSettings> &pconfig);
+  void setPlanningConfigurations(const PlanningConfigurationMap &pconfig);
 
   /* \brief Get the maximum number of sampling attempts allowed when sampling states is needed */
   unsigned int getMaximumStateSamplingAttempts() const
@@ -171,7 +172,7 @@ public:
   
   ConfiguredPlannerSelector getPlannerSelector() const;
 
-  const std::map<std::string, PlanningConfigurationSettings>& getPlanningConfigurations() const
+  const PlanningConfigurationMap& getPlanningConfigurations() const
   {
     return planner_configs_;
   }
@@ -221,7 +222,7 @@ protected:
 
   /// the minimum number of points to include on the solution path (interpolation is used to reach this number, if needed)
   unsigned int                                          minimum_waypoint_count_;
-  
+
 private:
   
   class LastPlanningContext;

--- a/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -66,6 +66,7 @@ public:
   
   /** @brief Specify configurations for the planners.
       @param pconfig Configurations for the different planners */
+  //void setPlanningConfigurations(const PlanningConfigurationMap &pconfig);
   void setPlanningConfigurations(const PlanningConfigurationMap &pconfig);
 
   /* \brief Get the maximum number of sampling attempts allowed when sampling states is needed */

--- a/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/planning_context_manager.h
@@ -66,7 +66,6 @@ public:
   
   /** @brief Specify configurations for the planners.
       @param pconfig Configurations for the different planners */
-  //void setPlanningConfigurations(const PlanningConfigurationMap &pconfig);
   void setPlanningConfigurations(const PlanningConfigurationMap &pconfig);
 
   /* \brief Get the maximum number of sampling attempts allowed when sampling states is needed */

--- a/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -32,7 +32,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: Ioan Sucan */
+/* Author: Ioan Sucan, Dave Coleman */
 
 #include <moveit/ompl_interface/detail/state_validity_checker.h>
 #include <moveit/ompl_interface/model_based_planning_context.h>

--- a/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -1,43 +1,43 @@
 /*********************************************************************
- * Software License Agreement (BSD License)
- *
- *  Copyright (c) 2011, Willow Garage, Inc.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *********************************************************************/
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2011, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
 
 /* Author: Ioan Sucan */
 
 #include <moveit/ompl_interface/detail/state_validity_checker.h>
 #include <moveit/ompl_interface/model_based_planning_context.h>
 #include <moveit/profiler/profiler.h>
-#include <ros/ros.h> 
+#include <ros/ros.h>
 
 ompl_interface::StateValidityChecker::StateValidityChecker(const ModelBasedPlanningContext *pc) :
   ompl::base::StateValidityChecker(pc->getOMPLSimpleSetup().getSpaceInformation()), planning_context_(pc),
@@ -45,17 +45,17 @@ ompl_interface::StateValidityChecker::StateValidityChecker(const ModelBasedPlann
 {
   specs_.clearanceComputationType = ompl::base::StateValidityCheckerSpecs::APPROXIMATE;
   specs_.hasValidDirectionComputation = false;
-
+  
   collision_request_with_distance_.distance = true;
   collision_request_with_cost_.cost = true;
 
   collision_request_simple_.group_name = planning_context_->getJointModelGroupName();
   collision_request_with_distance_.group_name = planning_context_->getJointModelGroupName();
   collision_request_with_cost_.group_name = planning_context_->getJointModelGroupName();
-
+  
   collision_request_simple_verbose_ = collision_request_simple_;
   collision_request_simple_verbose_.verbose = true;
-
+  
   collision_request_with_distance_verbose_ = collision_request_with_distance_;
   collision_request_with_distance_verbose_.verbose = true;
 }
@@ -66,7 +66,7 @@ void ompl_interface::StateValidityChecker::setVerbose(bool flag)
 }
 
 bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State *state, bool verbose) const
-{
+{  
   //  moveit::Profiler::ScopedBlock sblock("isValid");
   return planning_context_->useStateValidityCache() ? isValidWithCache(state, verbose) : isValidWithoutCache(state, verbose);
 }
@@ -78,63 +78,64 @@ bool ompl_interface::StateValidityChecker::isValid(const ompl::base::State *stat
 }
 
 double ompl_interface::StateValidityChecker::cost(const ompl::base::State *state) const
-{
-  static std::vector<double> prev_joint_values;
-  static bool first_time = true;
-  static boost::thread::id thread_id = boost::this_thread::get_id();
-
-  // Check that we are still on same thread
-  if( thread_id != boost::this_thread::get_id() )
-    ROS_ERROR_STREAM("Multiple threads are not implemented here...");
-
-  // Get current robot state
-  robot_state::RobotState *kstate = tss_.getStateStorage();
-  planning_context_->getOMPLStateSpace()->copyToRobotState(*kstate, state);
-
-  // Cost
+{ 
+  bool useCollisionDistanceCost = false; // TODO - set this somewhere else
   double cost = 0.0;
-  std::vector<double> new_joint_values;
 
-  // get joint state values
-  kstate->getStateValues(new_joint_values);
-
-  // calculate cost
-  for (std::size_t i = 0; i < new_joint_values.size(); ++i)
+  if( useCollisionDistanceCost ) // proximity to collisions cost
   {
-    double value = 0;
-    // Check if first time
-    if (first_time)
-    {
-      first_time = false;
-      prev_joint_values.resize(new_joint_values.size());
-    }
-    else
-    {
-      // get abs of difference in each joint value
-      value = fabs(prev_joint_values[i] - new_joint_values[i]);
-    }
-
-    cost += value;
-
-    // copy new value to old vector
-    prev_joint_values[i] = new_joint_values[i];
-  }
-
-  return cost;
-
-  /*
     robot_state::RobotState *kstate = tss_.getStateStorage();
     planning_context_->getOMPLStateSpace()->copyToRobotState(*kstate, state);
 
     collision_detection::CollisionResult res;
     planning_context_->getPlanningScene()->checkCollision(collision_request_with_cost_, res, *kstate);
 
-    double c = 0.0;
     for (std::set<collision_detection::CostSource>::const_iterator it = res.cost_sources.begin() ; it != res.cost_sources.end() ; ++it)
-    c += it->cost * it->getVolume();
+      cost += it->cost * it->getVolume();
+  }
+  else // use distance between joints cost
+  {
+    static std::vector<double> prev_joint_values;
+    static bool first_time = true;
+    static boost::thread::id thread_id = boost::this_thread::get_id();
 
-    return c;
-  */
+    // Check that we are still on same thread
+    if( thread_id != boost::this_thread::get_id() )
+      ROS_ERROR_STREAM("Multiple threads are not implemented here...");
+
+    // Get current robot state
+    robot_state::RobotState *kstate = tss_.getStateStorage();
+    planning_context_->getOMPLStateSpace()->copyToRobotState(*kstate, state);
+ 
+    std::vector<double> new_joint_values;
+
+    // get joint state values
+    kstate->getStateValues(new_joint_values);
+
+    // calculate cost
+    for (std::size_t i = 0; i < new_joint_values.size(); ++i)
+    {
+      double value = 0;
+      // Check if first time
+      if (first_time)
+      {
+        first_time = false;
+        prev_joint_values.resize(new_joint_values.size());
+      }
+      else
+      {
+        // get abs of difference in each joint value
+        value = fabs(prev_joint_values[i] - new_joint_values[i]);
+      }
+
+      cost += value;
+
+      // copy new value to old vector
+      prev_joint_values[i] = new_joint_values[i];
+    }
+  }
+
+  return cost;
 }
 
 double ompl_interface::StateValidityChecker::clearance(const ompl::base::State *state) const
@@ -152,22 +153,22 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      logInform("State outside bounds");
+      logInform("State outside bounds");   
     return false;
   }
-
+  
   robot_state::RobotState *kstate = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*kstate, state);
-
+  
   // check path constraints
   const kinematic_constraints::KinematicConstraintSetPtr &kset = planning_context_->getPathConstraints();
   if (kset && !kset->decide(*kstate, verbose).satisfied)
     return false;
-
+  
   // check feasibility
   if (!planning_context_->getPlanningScene()->isStateFeasible(*kstate, verbose))
     return false;
-
+  
   // check collision avoidance
   collision_detection::CollisionResult res;
   planning_context_->getPlanningScene()->checkCollision(verbose ? collision_request_simple_verbose_ : collision_request_simple_, res, *kstate);
@@ -185,7 +186,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
 
   robot_state::RobotState *kstate = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*kstate, state);
-
+  
   // check path constraints
   const kinematic_constraints::KinematicConstraintSetPtr &kset = planning_context_->getPathConstraints();
   if (kset)
@@ -193,18 +194,18 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
     kinematic_constraints::ConstraintEvaluationResult cer = kset->decide(*kstate, verbose);
     if (!cer.satisfied)
     {
-      dist = cer.distance;
+      dist = cer.distance;    
       return false;
     }
   }
-
+  
   // check feasibility
   if (!planning_context_->getPlanningScene()->isStateFeasible(*kstate, verbose))
   {
-    dist = 0.0;
+    dist = 0.0;   
     return false;
   }
-
+  
   // check collision avoidance
   collision_detection::CollisionResult res;
   planning_context_->getPlanningScene()->checkCollision(verbose ? collision_request_with_distance_verbose_ : collision_request_with_distance_, res, *kstate);
@@ -215,16 +216,16 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
 bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::State *state, bool verbose) const
 {
   if (state->as<ModelBasedStateSpace::StateType>()->isValidityKnown())
-    return state->as<ModelBasedStateSpace::StateType>()->isMarkedValid();
-
+    return state->as<ModelBasedStateSpace::StateType>()->isMarkedValid();  
+  
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      logInform("State outside bounds");
+      logInform("State outside bounds");   
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
     return false;
   }
-
+  
   robot_state::RobotState *kstate = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*kstate, state);
 
@@ -232,17 +233,17 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   const kinematic_constraints::KinematicConstraintSetPtr &kset = planning_context_->getPathConstraints();
   if (kset && !kset->decide(*kstate, verbose).satisfied)
   {
-    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
+    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();   
     return false;
   }
-
+  
   // check feasibility
   if (!planning_context_->getPlanningScene()->isStateFeasible(*kstate, verbose))
-  {
-    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
+  {    
+    const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid(); 
     return false;
   }
-
+  
   // check collision avoidance
   collision_detection::CollisionResult res;
   planning_context_->getPlanningScene()->checkCollision(verbose ? collision_request_simple_verbose_ : collision_request_simple_, res, *kstate);
@@ -250,7 +251,7 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
   {
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markValid();
     return true;
-  }
+  } 
   else
   {
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid();
@@ -259,24 +260,24 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
 }
 
 bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::State *state, double &dist, bool verbose) const
-{
+{ 
   if (state->as<ModelBasedStateSpace::StateType>()->isValidityKnown() && state->as<ModelBasedStateSpace::StateType>()->isGoalDistanceKnown())
   {
     dist = state->as<ModelBasedStateSpace::StateType>()->distance;
     return state->as<ModelBasedStateSpace::StateType>()->isMarkedValid();
   }
-
+  
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
-      logInform("State outside bounds");
+      logInform("State outside bounds");  
     const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid(0.0);
     return false;
   }
 
   robot_state::RobotState *kstate = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*kstate, state);
-
+  
   // check path constraints
   const kinematic_constraints::KinematicConstraintSetPtr &kset = planning_context_->getPathConstraints();
   if (kset)
@@ -284,19 +285,19 @@ bool ompl_interface::StateValidityChecker::isValidWithCache(const ompl::base::St
     kinematic_constraints::ConstraintEvaluationResult cer = kset->decide(*kstate, verbose);
     if (!cer.satisfied)
     {
-      dist = cer.distance;
-      const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid(dist);
+      dist = cer.distance;   
+      const_cast<ob::State*>(state)->as<ModelBasedStateSpace::StateType>()->markInvalid(dist); 
       return false;
     }
   }
-
+  
   // check feasibility
   if (!planning_context_->getPlanningScene()->isStateFeasible(*kstate, verbose))
   {
     dist = 0.0;
     return false;
   }
-
+  
   // check collision avoidance
   collision_detection::CollisionResult res;
   planning_context_->getPlanningScene()->checkCollision(verbose ? collision_request_with_distance_verbose_ : collision_request_with_distance_, res, *kstate);

--- a/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -37,15 +37,12 @@
 #include <moveit/ompl_interface/detail/state_validity_checker.h>
 #include <moveit/ompl_interface/model_based_planning_context.h>
 #include <moveit/profiler/profiler.h>
-#include <ros/ros.h> // DTC
-#include <math.h> // DTC
+#include <ros/ros.h> 
 
 ompl_interface::StateValidityChecker::StateValidityChecker(const ModelBasedPlanningContext *pc) :
   ompl::base::StateValidityChecker(pc->getOMPLSimpleSetup().getSpaceInformation()), planning_context_(pc),
   group_name_(pc->getJointModelGroupName()), tss_(pc->getCompleteInitialRobotState()), verbose_(false)
 {
-  ROS_ERROR_STREAM_NAMED("temp","Initialized");
-
   specs_.clearanceComputationType = ompl::base::StateValidityCheckerSpecs::APPROXIMATE;
   specs_.hasValidDirectionComputation = false;
 
@@ -115,7 +112,6 @@ double ompl_interface::StateValidityChecker::cost(const ompl::base::State *state
     {
       // get abs of difference in each joint value
       value = fabs(prev_joint_values[i] - new_joint_values[i]);
-      //ROS_DEBUG_STREAM_NAMED("temp","difference is " << value << " old: " << prev_joint_values[i] << " new: " << new_joint_values[i]);
     }
 
     cost += value;
@@ -124,7 +120,6 @@ double ompl_interface::StateValidityChecker::cost(const ompl::base::State *state
     prev_joint_values[i] = new_joint_values[i];
   }
 
-  //ROS_ERROR_STREAM_NAMED("temp",boost::this_thread::get_id() << ": state_validity_checker->cost() c=" << c);
   return cost;
 
   /*

--- a/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -189,7 +189,8 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   
   if (cfg.empty())
     return;
-  
+
+  // remove the 'type' parameter; the rest are parameters for the planner itself  
   it = cfg.find("type");
   if (it == cfg.end())
   {
@@ -198,7 +199,6 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   }
   else
   {
-    // remove the 'type' parameter; the rest are parameters for the planner itself
     std::string type = it->second;
     cfg.erase(it);
     ompl_simple_setup_.setPlannerAllocator(boost::bind(spec_.planner_selector_(type), _1,
@@ -206,7 +206,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     logInform("Planner configuration '%s' will use planner '%s'. Additional configuration parameters will be set when the planner is constructed.",
               name_.c_str(), type.c_str());
   }
-  
+
   // call the setParams() after setup(), so we know what the params are
   ompl_simple_setup_.getSpaceInformation()->setup();
   ompl_simple_setup_.getSpaceInformation()->params().setParams(cfg, true);

--- a/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/ompl/ompl_interface/src/ompl_interface.cpp
@@ -324,7 +324,8 @@ void ompl_interface::OMPLInterface::loadParams()
 void ompl_interface::OMPLInterface::loadPlannerConfigurations()
 {
   const std::vector<std::string> &group_names = kmodel_->getJointModelGroupNames();  
-  std::vector<ompl_interface::PlanningConfigurationSettings> pconfig;
+  ompl_interface::PlanningConfigurationMap pconfig;
+
   // read the planning configuration for each group
   pconfig.clear();
   for (std::size_t i = 0 ; i < group_names.size() ; ++i)
@@ -334,7 +335,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
       "projection_evaluator", "longest_valid_segment_fraction"
     };
     
-    // get parameters specific for the group
+    // get parameters specific for the robot planning group
     std::map<std::string, std::string> specific_group_params;
     for (std::size_t k = 0 ; k < sizeof(KNOWN_GROUP_PARAMS) / sizeof(std::string) ; ++k)
     {
@@ -374,9 +375,10 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
       pc.name = group_names[i];
       pc.group = group_names[i];
       pc.config = specific_group_params;
-      pconfig.push_back(pc);
+      pconfig[pc.name] = pc;
     }
     
+    // get parameters specific to each planner type
     XmlRpc::XmlRpcValue config_names;
     if (nh_.getParam(group_names[i] + "/planner_configs", config_names))
     {
@@ -410,7 +412,7 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
 		      else
 			if (it->second.getType() == XmlRpc::XmlRpcValue::TypeBoolean)
 			  pc.config[it->first] = boost::lexical_cast<std::string>(static_cast<bool>(it->second));
-		pconfig.push_back(pc);
+                pconfig[pc.name] = pc;
 	      }
 	      else
 		ROS_ERROR("A planning configuration should be of type XmlRpc Struct type (for configuration '%s')", planner_config.c_str());
@@ -426,11 +428,13 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
     }
   }
   
-  for (std::size_t i = 0 ; i < pconfig.size() ; ++i)
+  for(ompl_interface::PlanningConfigurationMap::iterator it = pconfig.begin(); 
+      it != pconfig.end(); ++it)
   {
-    ROS_DEBUG_STREAM("Parameters for configuration '"<< pconfig[i].name << "'");
-    for (std::map<std::string, std::string>::const_iterator it = pconfig[i].config.begin() ; it != pconfig[i].config.end() ; ++it)
-      ROS_DEBUG_STREAM(it->first << " = " << it->second);
+    ROS_DEBUG_STREAM("Parameters for configuration '"<< it->first << "'");
+    for (std::map<std::string, std::string>::const_iterator config_it = it->second.config.begin() ; 
+         config_it != it->second.config.end() ; ++config_it)
+      ROS_DEBUG_STREAM(" - " << config_it->first << " = " << config_it->second);
   }
   setPlanningConfigurations(pconfig);
 }

--- a/ompl/ompl_interface/src/ompl_interface_ros.cpp
+++ b/ompl/ompl_interface/src/ompl_interface_ros.cpp
@@ -82,7 +82,8 @@ void ompl_interface::OMPLInterfaceROS::loadParams()
 void ompl_interface::OMPLInterfaceROS::loadPlannerConfigurations()
 {
   const std::vector<std::string> &group_names = kmodel_->getJointModelGroupNames();  
-  std::vector<ompl_interface::PlanningConfigurationSettings> pconfig;
+  ompl_interface::PlanningConfigurationMap pconfig;
+
   // read the planning configuration for each group
   pconfig.clear();
   for (std::size_t i = 0 ; i < group_names.size() ; ++i)
@@ -92,7 +93,7 @@ void ompl_interface::OMPLInterfaceROS::loadPlannerConfigurations()
       "projection_evaluator", "longest_valid_segment_fraction"
     };
     
-    // get parameters specific for the group
+    // get parameters specific for the robot planning group
     std::map<std::string, std::string> specific_group_params;
     for (std::size_t k = 0 ; k < sizeof(KNOWN_GROUP_PARAMS) / sizeof(std::string) ; ++k)
     {
@@ -132,15 +133,17 @@ void ompl_interface::OMPLInterfaceROS::loadPlannerConfigurations()
       pc.name = group_names[i];
       pc.group = group_names[i];
       pc.config = specific_group_params;
-      pconfig.push_back(pc);
+      pconfig[pc.name] = pc;
     }
     
+    // get parameters specific to each planner type
     XmlRpc::XmlRpcValue config_names;
     if (nh_.getParam(group_names[i] + "/planner_configs", config_names))
     {
       if (config_names.getType() == XmlRpc::XmlRpcValue::TypeArray)
       {
 	for (int32_t j = 0; j < config_names.size() ; ++j)
+        {
 	  if (config_names[j].getType() == XmlRpc::XmlRpcValue::TypeString)
 	  {
 	    std::string planner_config = static_cast<std::string>(config_names[j]);
@@ -168,7 +171,9 @@ void ompl_interface::OMPLInterfaceROS::loadPlannerConfigurations()
 		      else
 			if (it->second.getType() == XmlRpc::XmlRpcValue::TypeBoolean)
 			  pc.config[it->first] = boost::lexical_cast<std::string>(static_cast<bool>(it->second));
-		pconfig.push_back(pc);
+
+
+                pconfig[pc.name] = pc;
 	      }
 	      else
 		ROS_ERROR("A planning configuration should be of type XmlRpc Struct type (for configuration '%s')", planner_config.c_str());
@@ -178,17 +183,21 @@ void ompl_interface::OMPLInterfaceROS::loadPlannerConfigurations()
 	  }
 	  else
 	    ROS_ERROR("Planner configuration names must be of type string (for group '%s')", group_names[i].c_str());
+        }
       }
       else
 	ROS_ERROR("The planner_configs argument of a group configuration should be an array of strings (for group '%s')", group_names[i].c_str());
     }
   }
-  
-  for (std::size_t i = 0 ; i < pconfig.size() ; ++i)
+
+
+  for(ompl_interface::PlanningConfigurationMap::iterator it = pconfig.begin(); 
+      it != pconfig.end(); ++it) 
   {
-    ROS_DEBUG_STREAM("Parameters for configuration '"<< pconfig[i].name << "'");
-    for (std::map<std::string, std::string>::const_iterator it = pconfig[i].config.begin() ; it != pconfig[i].config.end() ; ++it)
-      ROS_DEBUG_STREAM(it->first << " = " << it->second);
+    ROS_DEBUG_STREAM("Parameters for configuration '"<< it->first << "'");
+    for (std::map<std::string, std::string>::const_iterator config_it = it->second.config.begin() ; 
+         config_it != it->second.config.end() ; ++config_it)
+      ROS_DEBUG_STREAM(" - " << config_it->first << " = " << config_it->second);
   }
   setPlanningConfigurations(pconfig);
 }

--- a/ompl/ompl_interface/src/ompl_plugin.cpp
+++ b/ompl/ompl_interface/src/ompl_plugin.cpp
@@ -156,7 +156,8 @@ public:
 
       // Copy config map
       planning_config.config.clear();
-      planning_config.config.insert(pconfig_it->second.config.begin(),pconfig_it->second.config.end());
+      planning_config.config.insert(pconfig_it->second.config.begin(),
+        pconfig_it->second.config.end());
 
       // Add to the map
       planning_pconfig[pconfig_it->first] = planning_config;

--- a/ompl/ompl_interface/src/ompl_plugin.cpp
+++ b/ompl/ompl_interface/src/ompl_plugin.cpp
@@ -97,7 +97,7 @@ public:
                      planning_interface::MotionPlanDetailedResponse &res) const
   {
     display_random_valid_states_ = false;
-    logError("ompl_plugin - solve()");
+
     bool r = ompl_interface_->solve(planning_scene, req, res);
     if (!planner_data_link_name_.empty())
       displayPlannerData(planning_scene, planner_data_link_name_);

--- a/ompl/ompl_interface/src/ompl_plugin.cpp
+++ b/ompl/ompl_interface/src/ompl_plugin.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan */
+/* Author: Ioan Sucan, Dave Coleman */
 
 #include <moveit/ompl_interface/ompl_interface.h>
 #include <moveit/planning_interface/planning_interface.h>

--- a/ompl/ompl_interface/src/ompl_plugin.cpp
+++ b/ompl/ompl_interface/src/ompl_plugin.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2011, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Ioan Sucan */
 
@@ -54,14 +54,14 @@ using namespace moveit_planners_ompl;
 class OMPLPlanner : public planning_interface::Planner
 {
 public:
-  
+
   OMPLPlanner() : planning_interface::Planner(),
                   nh_("~"),
 		  display_random_valid_states_(false)
   {
   }
-  
-  virtual bool initialize(const robot_model::RobotModelConstPtr& model, const std::string &ns) 
+
+  virtual bool initialize(const robot_model::RobotModelConstPtr& model, const std::string &ns)
   {
     if (!ns.empty())
       nh_ = ros::NodeHandle(ns);
@@ -74,14 +74,14 @@ public:
     dynamic_reconfigure_server_->setCallback(boost::bind(&OMPLPlanner::dynamicReconfigureCallback, this, _1, _2));
     return true;
   }
-  
+
   bool canServiceRequest(const moveit_msgs::MotionPlanRequest &req) const
   {
     return true;
   }
-  
+
   virtual bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                     const planning_interface::MotionPlanRequest &req, 
+                     const planning_interface::MotionPlanRequest &req,
                      planning_interface::MotionPlanResponse &res) const
   {
     display_random_valid_states_ = false;
@@ -91,37 +91,89 @@ public:
       displayPlannerData(planning_scene, planner_data_link_name_);
     return r;
   }
-  
+
   virtual bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                     const planning_interface::MotionPlanRequest &req, 
+                     const planning_interface::MotionPlanRequest &req,
                      planning_interface::MotionPlanDetailedResponse &res) const
   {
     display_random_valid_states_ = false;
+    logError("ompl_plugin - solve()");
     bool r = ompl_interface_->solve(planning_scene, req, res);
     if (!planner_data_link_name_.empty())
       displayPlannerData(planning_scene, planner_data_link_name_);
     return r;
   }
-  
+
   std::string getDescription() const { return "OMPL"; }
-  
+
   void getPlanningAlgorithms(std::vector<std::string> &algs) const
   {
-    const std::map<std::string, ompl_interface::PlanningConfigurationSettings> &pconfig = 
+    const std::map<std::string, ompl_interface::PlanningConfigurationSettings> &pconfig =
       ompl_interface_->getPlanningContextManager().getPlanningConfigurations();
     algs.clear();
-    for (std::map<std::string, ompl_interface::PlanningConfigurationSettings>::const_iterator it = pconfig.begin() ; 
+    for (std::map<std::string, ompl_interface::PlanningConfigurationSettings>::const_iterator it = pconfig.begin() ;
          it != pconfig.end() ; ++it)
       algs.push_back(it->first);
   }
-  
+
+  void setPlanningConfigurations(const planning_interface::PlanningConfigurationMap &pconfig) const
+  {
+
+    // Convert plannning_interface map to ompl_interface map
+    ompl_interface::PlanningConfigurationMap ompl_pconfig_map;
+
+    for(planning_interface::PlanningConfigurationMap::const_iterator pconfig_it =
+          pconfig.begin(); pconfig_it != pconfig.end(); ++pconfig_it)
+    {
+      // Convert planning_interface struct to ompl_interface struct
+      ompl_interface::PlanningConfigurationSettings ompl_pconfig;
+      ompl_pconfig.name = pconfig_it->second.name;
+      ompl_pconfig.group = pconfig_it->second.group;
+
+      // Copy config map
+      ompl_pconfig.config.clear();
+      ompl_pconfig.config.insert(pconfig_it->second.config.begin(),pconfig_it->second.config.end());
+
+      ompl_pconfig_map[pconfig_it->second.name] = ompl_pconfig;
+    }
+
+    ompl_interface_->setPlanningConfigurations(ompl_pconfig_map);
+  }
+
+  const planning_interface::PlanningConfigurationMap getPlanningConfigurations() const
+  {
+    planning_interface::PlanningConfigurationMap planning_pconfig;
+
+    // Convert the ompl interface version to the planning interface version
+    ompl_interface::PlanningConfigurationMap ompl_pconfig;
+    ompl_pconfig = ompl_interface_->getPlanningConfigurations();
+
+    for(ompl_interface::PlanningConfigurationMap::const_iterator pconfig_it = ompl_pconfig.begin();
+        pconfig_it != ompl_pconfig.end(); ++pconfig_it)
+    {
+      // Convert settings to planning version
+      planning_interface::PlanningConfigurationSettings planning_config;
+      planning_config.name = pconfig_it->second.name;
+      planning_config.group = pconfig_it->second.group;
+
+      // Copy config map
+      planning_config.config.clear();
+      planning_config.config.insert(pconfig_it->second.config.begin(),pconfig_it->second.config.end());
+
+      // Add to the map
+      planning_pconfig[pconfig_it->first] = planning_config;
+    }
+
+    return planning_pconfig;
+  }
+
   void terminate() const
   {
     ompl_interface_->terminateSolve();
   }
-  
+
 private:
-  
+
   void displayRandomValidStates()
   {
     const ompl_interface::ModelBasedPlanningContextPtr &pc = ompl_interface_->getLastPlanningContext();
@@ -170,19 +222,19 @@ private:
       rstate2 = rstate1;
       wait.sleep();
     }
-    
+
   }
-  
+
   void displayPlannerData(const planning_scene::PlanningSceneConstPtr& planning_scene,
                           const std::string &link_name) const
-  {    
+  {
     const ompl_interface::ModelBasedPlanningContextPtr &pc = ompl_interface_->getLastPlanningContext();
     if (pc)
     {
       ompl::base::PlannerData pd(pc->getOMPLSimpleSetup().getSpaceInformation());
       pc->getOMPLSimpleSetup().getPlannerData(pd);
-      robot_state::RobotState kstate = planning_scene->getCurrentState();  
-      visualization_msgs::MarkerArray arr; 
+      robot_state::RobotState kstate = planning_scene->getCurrentState();
+      visualization_msgs::MarkerArray arr;
       std_msgs::ColorRGBA color;
       color.r = 1.0f;
       color.g = 0.25f;
@@ -194,7 +246,7 @@ private:
         pc->getOMPLStateSpace()->copyToRobotState(kstate, pd.getVertex(i).getState());
         kstate.getJointStateGroup(pc->getJointModelGroupName())->updateLinkTransforms();
         const Eigen::Vector3d &pos = kstate.getLinkState(link_name)->getGlobalLinkTransform().translation();
-	
+
         visualization_msgs::Marker mk;
         mk.header.stamp = ros::Time::now();
         mk.header.frame_id = planning_scene->getPlanningFrame();
@@ -211,10 +263,10 @@ private:
         mk.lifetime = ros::Duration(30.0);
         arr.markers.push_back(mk);
       }
-      pub_markers_.publish(arr); 
+      pub_markers_.publish(arr);
     }
   }
-  
+
   void dynamicReconfigureCallback(OMPLDynamicReconfigureConfig &config, uint32_t level)
   {
     if (config.link_for_exploration_tree.empty() && !planner_data_link_name_.empty())
@@ -240,11 +292,11 @@ private:
     else
       if (!display_random_valid_states_ && config.display_random_valid_states)
       {
-	display_random_valid_states_ = true; 
+	display_random_valid_states_ = true;
 	pub_valid_states_thread_.reset(new boost::thread(boost::bind(&OMPLPlanner::displayRandomValidStates, this)));
       }
   }
-  
+
   ros::NodeHandle nh_;
   boost::scoped_ptr<dynamic_reconfigure::Server<OMPLDynamicReconfigureConfig> > dynamic_reconfigure_server_;
   boost::scoped_ptr<OMPLInterfaceROS> ompl_interface_;

--- a/ompl/ompl_interface/src/ompl_plugin.cpp
+++ b/ompl/ompl_interface/src/ompl_plugin.cpp
@@ -90,7 +90,8 @@ public:
                      const planning_interface::MotionPlanRequest &req,
                      planning_interface::MotionPlanDetailedResponse &res) const
   {
-    display_random_valid_states_ = false;
+    // \todo re-enable this, I got error: assignment of member ‘ompl_interface::OMPLPlanner::display_random_valid_states_’ in read-only object
+    // display_random_valid_states_ = false;
 
     bool r = ompl_interface_->solve(planning_scene, req, res);
     if (!planner_data_link_name_.empty())

--- a/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2012, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Ioan Sucan */
 
@@ -63,13 +63,13 @@ namespace ompl_interface
 class PlanningContextManager::LastPlanningContext
 {
 public:
-  
+
   ModelBasedPlanningContextPtr getContext()
   {
     boost::mutex::scoped_lock slock(lock_);
     return last_planning_context_solve_;
   }
-  
+
   void setContext(const ModelBasedPlanningContextPtr &context)
   {
     boost::mutex::scoped_lock slock(lock_);
@@ -77,22 +77,22 @@ public:
   }
 
   void clear()
-  {    
+  {
     boost::mutex::scoped_lock slock(lock_);
     last_planning_context_solve_.reset();
   }
-  
+
 private:
   /* The planning group for which solve() was called last */
   ModelBasedPlanningContextPtr last_planning_context_solve_;
-  boost::mutex                 lock_;  
+  boost::mutex                 lock_;
 };
 
 struct PlanningContextManager::CachedContexts
 {
   std::map<std::pair<std::string, std::string>,
            std::vector<ModelBasedPlanningContextPtr> > contexts_;
-  boost::mutex                                         lock_;
+boost::mutex                                         lock_;
 };
 
 }
@@ -120,12 +120,12 @@ inline void auxPlannerConfig(const ob::PlannerPtr &planner, const ModelBasedPlan
 {
 }
 /*
-template<>
-inline void auxPlannerConfig<og::msRRTConnect>(const ob::PlannerPtr &planner, const ModelBasedPlanningContextSpecification &spec)
-{
+  template<>
+  inline void auxPlannerConfig<og::msRRTConnect>(const ob::PlannerPtr &planner, const ModelBasedPlanningContextSpecification &spec)
+  {
   for (std::size_t i = 0 ; i < spec.subspaces_.size() ; ++i)
-    planner->as<og::msRRTConnect>()->addExplorationSubspace(spec.subspaces_[i]);
-}
+  planner->as<og::msRRTConnect>()->addExplorationSubspace(spec.subspaces_[i]);
+  }
 */
 template<typename T>
 static ompl::base::PlannerPtr allocatePlanner(const ob::SpaceInformationPtr &si, const std::string &new_name, const ModelBasedPlanningContextSpecification &spec)
@@ -133,7 +133,7 @@ static ompl::base::PlannerPtr allocatePlanner(const ob::SpaceInformationPtr &si,
   ompl::base::PlannerPtr planner(new T(si));
   if (!new_name.empty())
     planner->setName(new_name);
-  planner->params().setParams(spec.config_, true);  
+  planner->params().setParams(spec.config_, true);
   auxPlannerConfig<T>(planner, spec);
   planner->setup();
   return planner;
@@ -152,14 +152,14 @@ ompl_interface::ConfiguredPlannerAllocator ompl_interface::PlanningContextManage
     return ConfiguredPlannerAllocator();
   }
 }
-  
+
 
 void ompl_interface::PlanningContextManager::registerDefaultPlanners()
 {
   registerPlannerAllocator("geometric::RRT", boost::bind(&allocatePlanner<og::RRT>, _1, _2, _3));
   registerPlannerAllocator("geometric::RRTConnect", boost::bind(&allocatePlanner<og::RRTConnect>, _1, _2, _3));
   //  registerPlannerAllocator("geometric::msRRTConnect", boost::bind(&allocatePlanner<og::msRRTConnect>, _1, _2, _3));
-  registerPlannerAllocator("geometric::LazyRRT", boost::bind(&allocatePlanner<og::LazyRRT>, _1, _2, _3)); 
+  registerPlannerAllocator("geometric::LazyRRT", boost::bind(&allocatePlanner<og::LazyRRT>, _1, _2, _3));
   registerPlannerAllocator("geometric::TRRT", boost::bind(&allocatePlanner<og::TRRT>, _1, _2, _3));
   registerPlannerAllocator("geometric::EST", boost::bind(&allocatePlanner<og::EST>, _1, _2, _3));
   registerPlannerAllocator("geometric::SBL", boost::bind(&allocatePlanner<og::SBL>, _1, _2, _3));
@@ -181,28 +181,32 @@ ompl_interface::ConfiguredPlannerSelector ompl_interface::PlanningContextManager
   return boost::bind(&PlanningContextManager::plannerSelector, this, _1);
 }
 
-void ompl_interface::PlanningContextManager::setPlanningConfigurations(const std::vector<PlanningConfigurationSettings> &pconfig)
+void ompl_interface::PlanningContextManager::setPlanningConfigurations(const PlanningConfigurationMap &pconfig)
 {
   planner_configs_.clear();
-  for (std::size_t i = 0 ; i < pconfig.size() ; ++i)
-    planner_configs_[pconfig[i].name] = pconfig[i];
+  planner_configs_.insert(pconfig.begin(), pconfig.end());  // copy the map to this map
 
   // construct default configurations
   const std::map<std::string, robot_model::JointModelGroup*>& groups = kmodel_->getJointModelGroupMap();
   for (std::map<std::string, robot_model::JointModelGroup*>::const_iterator it = groups.begin() ; it != groups.end() ; ++it)
+  {
     if (planner_configs_.find(it->first) == planner_configs_.end())
     {
       PlanningConfigurationSettings empty;
       empty.name = empty.group = it->first;
       planner_configs_[empty.name] = empty;
     }
+  }
 }
 
 ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextManager::getPlanningContext(const std::string &config, const std::string& factory_type) const
 {
-  std::map<std::string, PlanningConfigurationSettings>::const_iterator pc = planner_configs_.find(config);
+  PlanningConfigurationMap::const_iterator pc = planner_configs_.find(config);
+
   if (pc != planner_configs_.end())
+  {
     return getPlanningContext(pc->second, boost::bind(&PlanningContextManager::getStateSpaceFactory1, this, _1, factory_type));
+  }
   else
   {
     logError("Planning configuration '%s' was not found", config.c_str());
@@ -214,8 +218,10 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
                                                                                                         const FactoryTypeSelector &factory_selector) const
 {
   const ompl_interface::ModelBasedStateSpaceFactoryPtr &factory = factory_selector(config.group);
-  
+
+  // Check for a cached planning context
   ModelBasedPlanningContextPtr context;
+
   {
     boost::mutex::scoped_lock slock(cached_contexts_->lock_);
     std::map<std::pair<std::string, std::string>, std::vector<ModelBasedPlanningContextPtr> >::const_iterator cc =
@@ -225,13 +231,18 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       for (std::size_t i = 0 ; i < cc->second.size() ; ++i)
         if (cc->second[i].unique())
         {
-          logDebug("Reusing cached planning context");
+          logInform("Reusing cached planning context");
           context = cc->second[i];
+
+          // Update the context with our current planner configurations - needed for parameter sweeping
+          context->getSpecificationConfig() = config.config;
+
           break;
         }
     }
   }
-  
+
+  // Create a new planning context
   if (!context)
   {
     ModelBasedStateSpaceSpecification space_spec(kmodel_, config.group);
@@ -258,7 +269,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
         }
       }
     }
-    
+
     logDebug("Creating new planning context");
     context.reset(new ModelBasedPlanningContext(config.name, context_spec));
     {
@@ -276,14 +287,14 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
   else
     context->setMaximumSolutionSegmentLength(max_solution_segment_length_);
   context->setMinimumWaypointCount(minimum_waypoint_count_);
-  
+
   last_planning_context_->setContext(context);
-  return context;  
+  return context;
 }
 
 const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningContextManager::getStateSpaceFactory1(const std::string & /* dummy */, const std::string &factory_type) const
 {
-  std::map<std::string, ModelBasedStateSpaceFactoryPtr>::const_iterator f = 
+  std::map<std::string, ModelBasedStateSpaceFactoryPtr>::const_iterator f =
     factory_type.empty() ? state_space_factories_.begin() : state_space_factories_.find(factory_type);
   if (f != state_space_factories_.end())
     return f->second;
@@ -310,7 +321,7 @@ const ompl_interface::ModelBasedStateSpaceFactoryPtr& ompl_interface::PlanningCo
         prev_priority = priority;
       }
   }
-  
+
   if (best == state_space_factories_.end())
   {
     logError("There are no known state spaces that can represent the given planning problem");
@@ -331,15 +342,16 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
     logError("No group specified to plan for");
     return ModelBasedPlanningContextPtr();
   }
-  
+
   // identify the correct planning configuration
-  std::map<std::string, PlanningConfigurationSettings>::const_iterator pc = planner_configs_.end();
+  PlanningConfigurationMap::const_iterator pc = planner_configs_.end();
   if (!req.planner_id.empty())
   {
     pc = planner_configs_.find(req.planner_id.find(req.group_name) == std::string::npos ? req.group_name + "[" + req.planner_id + "]" : req.planner_id);
     if (pc == planner_configs_.end())
-      logWarn("Cannot find planning configuration for group '%s' using planner '%s'. Will use defaults instead.", 
+      logWarn("Cannot find planning configuration for group '%s' using planner '%s'. Will use defaults instead.",
               req.group_name.c_str(), req.planner_id.c_str());
+
   }
   if (pc == planner_configs_.end())
   {
@@ -350,7 +362,7 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       return ModelBasedPlanningContextPtr();
     }
   }
-  
+
   return getPlanningContext(pc->second, boost::bind(&PlanningContextManager::getStateSpaceFactory2, this, _1, req));
 }
 

--- a/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -186,7 +186,7 @@ ompl_interface::ConfiguredPlannerSelector ompl_interface::PlanningContextManager
 void ompl_interface::PlanningContextManager::setPlanningConfigurations(const ompl_interface::PlanningConfigurationMap &pconfig)
 {
   planner_configs_.clear();
-  planner_configs_.insert(pconfig.begin(), pconfig.end());  // copy the map to this map
+  planner_configs_ = pconfig;
 
   // construct default configurations
   const std::map<std::string, robot_model::JointModelGroup*>& groups = kmodel_->getJointModelGroupMap();
@@ -233,11 +233,11 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
       for (std::size_t i = 0 ; i < cc->second.size() ; ++i)
         if (cc->second[i].unique())
         {
-          logInform("Reusing cached planning context");
+          logDebug("Reusing cached planning context");
           context = cc->second[i];
 
           // Update the context with our current planner configurations - needed for parameter sweeping
-          context->getSpecificationConfig() = config.config;
+          context->setSpecificationConfig(config.config);
 
           break;
         }

--- a/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -59,8 +59,6 @@
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space_factory.h>
 #include <moveit/ompl_interface/parameterization/work_space/pose_model_state_space_factory.h>
 
-//typedef std::map<std::string, ompl_interface::PlanningConfigurationSettings> PlanningConfigurationMap; // TODO: remove this!
-
 namespace ompl_interface
 {
 class PlanningContextManager::LastPlanningContext

--- a/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -58,6 +58,8 @@
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space_factory.h>
 #include <moveit/ompl_interface/parameterization/work_space/pose_model_state_space_factory.h>
 
+//typedef std::map<std::string, ompl_interface::PlanningConfigurationSettings> PlanningConfigurationMap; // TODO: remove this!
+
 namespace ompl_interface
 {
 class PlanningContextManager::LastPlanningContext
@@ -95,7 +97,7 @@ struct PlanningContextManager::CachedContexts
 boost::mutex                                         lock_;
 };
 
-}
+} // namespace ompl_interface
 
 ompl_interface::PlanningContextManager::PlanningContextManager(const robot_model::RobotModelConstPtr &kmodel, const constraint_samplers::ConstraintSamplerManagerPtr &csm) :
   kmodel_(kmodel), constraint_sampler_manager_(csm),
@@ -139,7 +141,7 @@ static ompl::base::PlannerPtr allocatePlanner(const ob::SpaceInformationPtr &si,
   return planner;
 }
 
-}
+} // namespace ompl_interface
 
 ompl_interface::ConfiguredPlannerAllocator ompl_interface::PlanningContextManager::plannerSelector(const std::string &planner) const
 {
@@ -181,7 +183,7 @@ ompl_interface::ConfiguredPlannerSelector ompl_interface::PlanningContextManager
   return boost::bind(&PlanningContextManager::plannerSelector, this, _1);
 }
 
-void ompl_interface::PlanningContextManager::setPlanningConfigurations(const PlanningConfigurationMap &pconfig)
+void ompl_interface::PlanningContextManager::setPlanningConfigurations(const ompl_interface::PlanningConfigurationMap &pconfig)
 {
   planner_configs_.clear();
   planner_configs_.insert(pconfig.begin(), pconfig.end());  // copy the map to this map
@@ -201,7 +203,7 @@ void ompl_interface::PlanningContextManager::setPlanningConfigurations(const Pla
 
 ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextManager::getPlanningContext(const std::string &config, const std::string& factory_type) const
 {
-  PlanningConfigurationMap::const_iterator pc = planner_configs_.find(config);
+  ompl_interface::PlanningConfigurationMap::const_iterator pc = planner_configs_.find(config);
 
   if (pc != planner_configs_.end())
   {


### PR DESCRIPTION
Changes:
- Converted all std::vector<PlanningConfigurationSettings> to std::map<std::string, PlanningConfigurationSettings>
- Added hooks to getPlanningConfigurations() and setPlanningConfigurations() in various places
- Created a new cost function based on distance between joint positions. Made this default - should it be? Or should we stick with proximity to collisions cost?
- Added assignment such that the planning context config is reloaded every time a new plan is generated, regardless of the cached planning context

My apologies for the formatting changes, I undid some of it but its a lot of work.
