### PR TITLE
Fixed ModelBasedPlanningContext::clear() which was beyond intended scope

### DIFF
--- a/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -328,12 +328,12 @@ void ompl_interface::ModelBasedPlanningContext::setCompleteInitialState(const ro
 void ompl_interface::ModelBasedPlanningContext::clear()
 {
   ompl_simple_setup_.clear();
-  ompl_simple_setup_.clearStartStates();
-  ompl_simple_setup_.setGoal(ob::GoalPtr());
-  ompl_simple_setup_.setStateValidityChecker(ob::StateValidityCheckerPtr());
-  path_constraints_.reset();
-  goal_constraints_.clear();
-  getOMPLStateSpace()->setInterpolationFunction(InterpolationFunction());
+  //ompl_simple_setup_.clearStartStates();
+  //ompl_simple_setup_.setGoal(ob::GoalPtr());
+  //ompl_simple_setup_.setStateValidityChecker(ob::StateValidityCheckerPtr());
+  //path_constraints_.reset();
+  //goal_constraints_.clear();
+  //getOMPLStateSpace()->setInterpolationFunction(InterpolationFunction());
 }
 
 bool ompl_interface::ModelBasedPlanningContext::setPathConstraints(const moveit_msgs::Constraints &path_constraints,


### PR DESCRIPTION
The ModelBasedPlanningContext::clear() functions is expected to plan the inherent planner's data structure but instead cleared the whole context, causing segfaults in benchmarking.
