### PR TITLE
Removed duplicate call to setPlanningScene(), added various comments

### DIFF
--- a/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -86,7 +86,8 @@ double ompl_interface::StateValidityChecker::cost(const ompl::base::State *state
   
   robot_state::RobotState *kstate = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*kstate, state);
-  
+
+  // Calculates cost from a summation of distance to obstacles times the size of the obstacle
   collision_detection::CollisionResult res;
   planning_context_->getPlanningScene()->checkCollision(collision_request_with_cost_, res, *kstate);
   
@@ -108,6 +109,7 @@ double ompl_interface::StateValidityChecker::clearance(const ompl::base::State *
 
 bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base::State *state, bool verbose) const
 {
+  // check bounds
   if (!si_->satisfiesBounds(state))
   {
     if (verbose)
@@ -115,6 +117,7 @@ bool ompl_interface::StateValidityChecker::isValidWithoutCache(const ompl::base:
     return false;
   }
 
+  // convert ompl state to moveit robot state
   robot_state::RobotState *kstate = tss_.getStateStorage();
   planning_context_->getOMPLStateSpace()->copyToRobotState(*kstate, state);
 

--- a/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/ompl/ompl_interface/src/ompl_interface.cpp
@@ -79,7 +79,7 @@ void ompl_interface::OMPLInterface::setPlannerConfigurations(const planning_inte
 {
   planning_interface::PlannerConfigurationMap pconfig2 = pconfig;
   
-  // construct default configurations
+  // construct default configurations for planning groups that don't have configs already passed in
   const std::vector<const robot_model::JointModelGroup*>& groups = kmodel_->getJointModelGroups();
   for (std::size_t i = 0 ; i < groups.size() ; ++i)
   {

--- a/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -351,13 +351,11 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::PlanningContextMana
   {
     context->clear();
 
-    context->setPlanningScene(planning_scene);
-    context->setMotionPlanRequest(req);
-
     robot_state::RobotStatePtr start_state = planning_scene->getCurrentStateUpdated(req.start_state);
 
-    // set the planning scene
+    // Setup the context
     context->setPlanningScene(planning_scene);
+    context->setMotionPlanRequest(req);
     context->setCompleteInitialState(*start_state);
 
     context->setPlanningVolume(req.workspace_parameters);


### PR DESCRIPTION
There's just two lines in this PR of functional change - I found that the setPlanningScene() was being called twice and, looking into the functionality, it is unnecessary. I moved the `context->setMotionPlanRequest(req);` call down with it for better grouping.

There will probably be some more similar pull requests soon, but I'm going to try to keep them small for ease of merging. 
