### PR TITLE
Fixed bug which limited the number of plans considered to the number of ...

### DIFF
--- a/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -563,7 +563,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
     else
       for (unsigned int i = 0 ; i < max_planning_threads_ ; ++i)
         ompl_parallel_plan_.addPlanner(og::getDefaultPlanner(ompl_simple_setup_.getGoal()));
-    bool r = ompl_parallel_plan_.solve(ptc, 1, max_planning_threads_, true) == ompl::base::PlannerStatus::EXACT_SOLUTION;
+    bool r = ompl_parallel_plan_.solve(ptc, 1, count, true) == ompl::base::PlannerStatus::EXACT_SOLUTION;
     result = result && r;
       }
       n = count % max_planning_threads_;
@@ -576,7 +576,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
     else
       for (int i = 0 ; i < n ; ++i)
         ompl_parallel_plan_.addPlanner(og::getDefaultPlanner(ompl_simple_setup_.getGoal()));
-    bool r = ompl_parallel_plan_.solve(ptc, 1, n, true) == ompl::base::PlannerStatus::EXACT_SOLUTION;
+    bool r = ompl_parallel_plan_.solve(ptc, 1, count, true) == ompl::base::PlannerStatus::EXACT_SOLUTION;
     result = result && r;
       }
       last_plan_time_ = ompl::time::seconds(ompl::time::now() - start);


### PR DESCRIPTION
...threads.
A better fix would be to alter the ParallelPlanner to continue launching new threads until either
time runs out or max number of plans are found. Then it could run Dijkstra's only once. 
With such a fix, the model_based_planning_context::solve() would be much more straight forward. 
I just didn't want to try to edit the OMPL library. 
