### PR TITLE
Reorder compilation paths for OMPL

### DIFF
--- a/ompl/CMakeLists.txt
+++ b/ompl/CMakeLists.txt
@@ -36,12 +36,12 @@ include_directories(SYSTEM
                     ${Boost_INCLUDE_DIRS})
 
 include_directories(ompl_interface/include
-                    ${catkin_INCLUDE_DIRS}
-		    ${OMPL_INCLUDE_DIRS})
+                    ${OMPL_INCLUDE_DIRS}
+                    ${catkin_INCLUDE_DIRS})
 
+link_directories(${OMPL_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
-link_directories(${OMPL_LIBRARY_DIRS})
 
 add_subdirectory(ompl_interface)
 


### PR DESCRIPTION
The linker will always find the instance of libompl.so in the ROS installation first, regardless of whether the user has specified a different install of OMPL.  This change rearranges the link order to put OMPL before the catkin directives to ensure linking of the correct OMPL library.
