### PR TITLE
Removed the const qualifier on all the solve() functions

### DIFF
--- a/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -80,19 +80,19 @@ public:
 
   /** @brief Solve the planning problem */
   bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-             const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanResponse &res) const;
+             const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanResponse &res) ;
 
   /** @brief Solve the planning problem but give a more detailed response */
   bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-             const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanDetailedResponse &res) const;
+             const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanDetailedResponse &res) ;
 
   ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                                  const planning_interface::MotionPlanRequest &req) const;
+                                                  const planning_interface::MotionPlanRequest &req) ;
   ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                   const planning_interface::MotionPlanRequest &req,
-                                                  moveit_msgs::MoveItErrorCodes &error_code) const;
+                                                  moveit_msgs::MoveItErrorCodes &error_code) ;
 
-  ModelBasedPlanningContextPtr getPlanningContext(const std::string &config, const std::string &factory_type = "") const;
+  ModelBasedPlanningContextPtr getPlanningContext(const std::string &config, const std::string &factory_type = "") ;
 
   ModelBasedPlanningContextPtr getLastPlanningContext() const
   {
@@ -176,7 +176,7 @@ protected:
   ModelBasedPlanningContextPtr prepareForSolve(const planning_interface::MotionPlanRequest &req,
                                                const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                moveit_msgs::MoveItErrorCodes *error_code,
-                                               unsigned int *attempts, double *timeout) const;
+                                               unsigned int *attempts, double *timeout) ;
 
 
   ros::NodeHandle nh_; /// The ROS node handle

--- a/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/ompl/ompl_interface/src/ompl_interface.cpp
@@ -95,7 +95,7 @@ void ompl_interface::OMPLInterface::setPlannerConfigurations(const planning_inte
 }
 
 ompl_interface::ModelBasedPlanningContextPtr ompl_interface::OMPLInterface::getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                                                                               const planning_interface::MotionPlanRequest &req) const
+                                                                                               const planning_interface::MotionPlanRequest &req) 
 {
   moveit_msgs::MoveItErrorCodes dummy;
   return getPlanningContext(planning_scene, req, dummy);
@@ -103,15 +103,16 @@ ompl_interface::ModelBasedPlanningContextPtr ompl_interface::OMPLInterface::getP
 
 ompl_interface::ModelBasedPlanningContextPtr ompl_interface::OMPLInterface::getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                                                                const planning_interface::MotionPlanRequest &req,
-                                                                                               moveit_msgs::MoveItErrorCodes &error_code) const
+                                                                                               moveit_msgs::MoveItErrorCodes &error_code) 
 {
+  loadPlannerConfigurations();
   ModelBasedPlanningContextPtr ctx = context_manager_.getPlanningContext(planning_scene, req, error_code);
   if (ctx)
     configureContext(ctx);
   return ctx;
 }
 
-ompl_interface::ModelBasedPlanningContextPtr ompl_interface::OMPLInterface::getPlanningContext(const std::string &config, const std::string &factory_type) const
+ompl_interface::ModelBasedPlanningContextPtr ompl_interface::OMPLInterface::getPlanningContext(const std::string &config, const std::string &factory_type) 
 {
   ModelBasedPlanningContextPtr ctx = context_manager_.getPlanningContext(config, factory_type);
   if (ctx)
@@ -129,7 +130,7 @@ void ompl_interface::OMPLInterface::configureContext(const ModelBasedPlanningCon
 }
 
 bool ompl_interface::OMPLInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                          const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanResponse &res) const
+                                          const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanResponse &res) 
 {
   moveit::tools::Profiler::ScopedStart pslv;
   moveit::tools::Profiler::ScopedBlock sblock("OMPLInterface:Solve");
@@ -145,7 +146,7 @@ bool ompl_interface::OMPLInterface::solve(const planning_scene::PlanningSceneCon
 }
 
 bool ompl_interface::OMPLInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                      const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanDetailedResponse &res) const
+                      const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanDetailedResponse &res) 
 {
   moveit::tools::Profiler::ScopedStart pslv;
   moveit::tools::Profiler::ScopedBlock sblock("OMPLInterface:Solve");


### PR DESCRIPTION
Removed the const qualifier on all the getPlanningContext() functions
Added a call to loadPlannerConfigurations() to the final getPlanningContext()
This allows changes in the ros parameters to take effect before solve()
The Planning Pipeline calls solve() by getting the context, and then context->sovle(),
NOT by calling the interface's solve() function. This is a work around to allow
on the fly updates of the parameters using the existing loadPlannerConfigurations() without altering
the plugin interface.
