### PR TITLE
Fix for New OMPL virtual function breaks build

### DIFF
--- a/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
@@ -198,6 +198,7 @@ public:
   virtual double distance(const ompl::base::State *state1, const ompl::base::State *state2) const;
   virtual bool equalStates(const ompl::base::State *state1, const ompl::base::State *state2) const;
   virtual double getMaximumExtent() const;
+  virtual double getMeasure() const;
 
   virtual unsigned int getSerializationLength() const;
   virtual void serialize(void *serialization, const ompl::base::State *state) const;

--- a/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -147,6 +147,20 @@ double ompl_interface::ModelBasedStateSpace::getMaximumExtent() const
   return spec_.joint_model_group_->getMaximumExtent(spec_.joint_bounds_);
 }
 
+double ompl_interface::ModelBasedStateSpace::getMeasure() const
+{
+    double m = 1.0;
+    for (std::size_t i = 0 ; i < spec_.joint_bounds_.size() ; ++i)
+    {
+        const robot_model::JointModel::Bounds& bounds = *spec_.joint_bounds_[i];
+        for (std::size_t j = 0; j < bounds.size(); ++j)
+        {
+            m *= bounds[j].max_position_ - bounds[j].min_position_;
+        }
+    }
+    return m;
+}
+
 double ompl_interface::ModelBasedStateSpace::distance(const ompl::base::State *state1, const ompl::base::State *state2) const
 {
   if (distance_function_)


### PR DESCRIPTION
I have not tested this at runtime but it does compile. 

Based on https://github.com/ros-planning/moveit_planners/pull/32

Issue https://github.com/ros-planning/moveit_planners/issues/31
