### PR TITLE
fix compile error on Indigo

### DIFF
--- a/ompl/ompl_interface/src/detail/ompl_console.cpp
+++ b/ompl/ompl_interface/src/detail/ompl_console.cpp
@@ -54,27 +54,27 @@ public:
     case ompl::msg::LOG_INFO:
       {
         ROSCONSOLE_DEFINE_LOCATION(true, ::ros::console::levels::Info, std::string(ROSCONSOLE_ROOT_LOGGER_NAME) + ".ompl");
-        if (ROS_UNLIKELY(enabled))
+        if (ROS_UNLIKELY(__rosconsole_define_location__enabled))
         {
-          ::ros::console::print(NULL, loc.logger_, loc.level_, filename, line, "", "%s", text.c_str());
+          ::ros::console::print(NULL, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_, filename, line, "", "%s", text.c_str());
         }
       }
       break;
     case ompl::msg::LOG_WARN:
       {
         ROSCONSOLE_DEFINE_LOCATION(true, ::ros::console::levels::Warn, std::string(ROSCONSOLE_ROOT_LOGGER_NAME) + ".ompl");
-        if (ROS_UNLIKELY(enabled))
+        if (ROS_UNLIKELY(__rosconsole_define_location__enabled))
         {
-          ::ros::console::print(NULL, loc.logger_, loc.level_, filename, line, "", "%s", text.c_str());
+          ::ros::console::print(NULL, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_, filename, line, "", "%s", text.c_str());
         }
       }
       break;
     case ompl::msg::LOG_ERROR:
       {
         ROSCONSOLE_DEFINE_LOCATION(true, ::ros::console::levels::Error, std::string(ROSCONSOLE_ROOT_LOGGER_NAME) + ".ompl");
-        if (ROS_UNLIKELY(enabled))
+        if (ROS_UNLIKELY(__rosconsole_define_location__enabled))
         {
-          ::ros::console::print(NULL, loc.logger_, loc.level_, filename, line, "", "%s", text.c_str());
+          ::ros::console::print(NULL, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_, filename, line, "", "%s", text.c_str());
         }
       }
       break;
@@ -82,9 +82,9 @@ public:
       // debug
       {
         ROSCONSOLE_DEFINE_LOCATION(true, ::ros::console::levels::Debug, std::string(ROSCONSOLE_ROOT_LOGGER_NAME) + ".ompl");
-        if (ROS_UNLIKELY(enabled))
+        if (ROS_UNLIKELY(__rosconsole_define_location__enabled))
         {
-          ::ros::console::print(NULL, loc.logger_, loc.level_, filename, line, "", "%s", text.c_str());
+          ::ros::console::print(NULL, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_, filename, line, "", "%s", text.c_str());
         }
       }
       break;


### PR DESCRIPTION
This patch will fix compiling issue related to Indigo (see http://wiki.ros.org/indigo/Migration).
