### PR TITLE
Namespace OMPL parameter configuration debug output

### DIFF
--- a/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/ompl/ompl_interface/src/ompl_interface.cpp
@@ -311,10 +311,10 @@ void ompl_interface::OMPLInterface::loadPlannerConfigurations()
   for(planning_interface::PlannerConfigurationMap::iterator it = pconfig.begin();
       it != pconfig.end(); ++it)
   {
-    ROS_DEBUG_STREAM("Parameters for configuration '"<< it->first << "'");
+    ROS_DEBUG_STREAM_NAMED("parameters","Parameters for configuration '"<< it->first << "'");
     for (std::map<std::string, std::string>::const_iterator config_it = it->second.config.begin() ;
          config_it != it->second.config.end() ; ++config_it)
-      ROS_DEBUG_STREAM(" - " << config_it->first << " = " << config_it->second);
+      ROS_DEBUG_STREAM_NAMED("parameters"," - " << config_it->first << " = " << config_it->second);
   }
   setPlannerConfigurations(pconfig);
 }


### PR DESCRIPTION
Currently when ros.moveit_planners_ompl console output is set to DEBUG it regurgitates the entire output of ompl_planning.yaml to console. This small changes prefixed it with 'parameters' to allow it to be easily ignored using ROS console.
