### PR TITLE
Added copy function from MoveIt! robot_state joint values to ompl state

### DIFF
--- a/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
@@ -239,12 +239,25 @@ public:
     return spec_.joint_bounds_;
   }
 
-  /// Copy the data from an OMPL state to a set of joint states. The join states \b must be specified in the same order as the joint models in the constructor
+  /// Copy the data from an OMPL state to a set of joint states.
+  // The joint states \b must be specified in the same order as the joint models in the constructor
   virtual void copyToRobotState(robot_state::RobotState &rstate, const ompl::base::State *state) const;
 
-  /// Copy the data from a set of joint states to an OMPL state. The join states \b must be specified in the same order as the joint models in the constructor
+  /// Copy the data from a set of joint states to an OMPL state.
+  //  The joint states \b must be specified in the same order as the joint models in the constructor
   virtual void copyToOMPLState(ompl::base::State *state, const robot_state::RobotState &rstate) const;
-  
+
+  /**
+   * \brief Copy a single joint's values (which might have multiple variables) from a MoveIt! robot_state to an OMPL state.
+   * \param state - output OMPL state with single joint modified
+   * \param robot_state - input MoveIt! state to get the joint value from
+   * \param joint_model - the joint to copy values of
+   * \param ompl_state_joint_index - the index of the joint in the ompl state (passed in for efficiency, you should cache this index)
+   *        e.g. ompl_state_joint_index = joint_model_group_->getVariableGroupIndex("virtual_joint");
+   */
+  virtual void copyJointToOMPLState(ompl::base::State *state, const robot_state::RobotState &robot_state,
+                                    const moveit::core::JointModel* joint_model, int ompl_state_joint_index) const;
+
   double getTagSnapToSegment() const;
   void setTagSnapToSegment(double snap);
 

--- a/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -320,5 +320,18 @@ void ompl_interface::ModelBasedStateSpace::copyToRobotState(robot_state::RobotSt
 void ompl_interface::ModelBasedStateSpace::copyToOMPLState(ompl::base::State *state, const robot_state::RobotState &rstate) const
 {
   rstate.copyJointGroupPositions(spec_.joint_model_group_, state->as<StateType>()->values);
+  // clear any cached info (such as validity known or not)
+  state->as<StateType>()->clearKnownInformation();
+}
+
+void ompl_interface::ModelBasedStateSpace::copyJointToOMPLState(ompl::base::State *state, const robot_state::RobotState &robot_state,
+                                                                const moveit::core::JointModel* joint_model, int ompl_state_joint_index) const
+{
+  // Copy one joint (multiple variables possibly)
+  memcpy(getValueAddressAtIndex(state, ompl_state_joint_index),
+         robot_state.getVariablePositions() + joint_model->getFirstVariableIndex() * sizeof(double),
+         joint_model->getVariableCount() * sizeof(double));
+
+  // clear any cached info (such as validity known or not)
   state->as<StateType>()->clearKnownInformation();
 }


### PR DESCRIPTION
New helper function to copy a single joint (that might have more than 1 variable e.g. floating joints) from the MoveIt! robot_state to an OMPL state. Very similar to `copyToOMPLState()` except reduces memory copies e.g. with humanoids 30 doubles to 1 double.
