### PR TITLE
Added check to resort to forcing random seeds for constrained sampling

### DIFF
--- a/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -90,7 +90,12 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
     
     if (constraint_sampler_)
     {
-      if (constraint_sampler_->project(work_state_, planning_context_->getMaximumStateSamplingAttempts()))
+      // if set to true, then the workstate is the seed, else it is randomized
+      bool use_workstate_as_seed = false;
+      if(a==0)
+        use_workstate_as_seed = true;
+
+      if (constraint_sampler_->project(work_state_, planning_context_->getMaximumStateSamplingAttempts(), use_workstate_as_seed))
       {
         work_state_.update();
         if (kinematic_constraint_set_->decide(work_state_, verbose).satisfied)


### PR DESCRIPTION
While looping over the number of attempts, it will force a randomized seed for calls to IK after the first failed attempt.

This is a solution to the problem talked about here:
https://github.com/ros-planning/moveit_planners/issues/44#issuecomment-50715025

Related request that enables this, otherwise this pull request won't work:
https://github.com/ros-planning/moveit_core/pull/188
