### PR TITLE
fix for demo constraints database linking error

### DIFF
--- a/ompl/CMakeLists.txt
+++ b/ompl/CMakeLists.txt
@@ -36,8 +36,8 @@ include_directories(SYSTEM
                     ${Boost_INCLUDE_DIRS})
 
 include_directories(ompl_interface/include
-                    ${OMPL_INCLUDE_DIRS}
-                    ${catkin_INCLUDE_DIRS})
+                    ${catkin_INCLUDE_DIRS}
+                    ${OMPL_INCLUDE_DIRS})
 
 link_directories(${OMPL_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})


### PR DESCRIPTION
This should fix the recent issue with moveit src not compiling. 
