### PR TITLE
Constraint sampling IK alternate bugfix

### DIFF
--- a/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
@@ -60,10 +60,10 @@ public:
 
 private:
 
-  bool sampleUsingConstraintSampler(const ompl::base::GoalLazySamples *gls, ompl::base::State *newGoal);
-  bool stateValidityCallback(ompl::base::State* newGoal, robot_state::RobotState const* state,
+  bool sampleUsingConstraintSampler(const ompl::base::GoalLazySamples *gls, ompl::base::State *new_goal);
+  bool stateValidityCallback(ompl::base::State* new_goal, robot_state::RobotState const* state,
                               const robot_model::JointModelGroup*, const double*, bool verbose=false) const;
-  bool checkStateValidity(ompl::base::State* newGoal, const robot_state::RobotState& state, bool verbose=false) const;
+  bool checkStateValidity(ompl::base::State* new_goal, const robot_state::RobotState& state, bool verbose=false) const;
 
   const ModelBasedPlanningContext                 *planning_context_;
   kinematic_constraints::KinematicConstraintSetPtr kinematic_constraint_set_;

--- a/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/detail/constrained_goal_sampler.h
@@ -41,6 +41,9 @@
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <moveit/constraint_samplers/constraint_sampler.h>
 
+#include <moveit/robot_state/robot_state.h>
+#include <moveit/robot_model/joint_model_group.h>
+
 namespace ompl_interface
 {
 
@@ -58,6 +61,9 @@ public:
 private:
 
   bool sampleUsingConstraintSampler(const ompl::base::GoalLazySamples *gls, ompl::base::State *newGoal);
+  bool stateValidityCallback(ompl::base::State* newGoal, robot_state::RobotState const* state,
+                              const robot_model::JointModelGroup*, const double*, bool verbose=false) const;
+  bool checkStateValidity(ompl::base::State* newGoal, const robot_state::RobotState& state, bool verbose=false) const;
 
   const ModelBasedPlanningContext                 *planning_context_;
   kinematic_constraints::KinematicConstraintSetPtr kinematic_constraint_set_;

--- a/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -58,15 +58,15 @@ ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(const ModelBasedP
   startSampling();
 }
 
-bool ompl_interface::ConstrainedGoalSampler::checkStateValidity(ob::State* newGoal,
+bool ompl_interface::ConstrainedGoalSampler::checkStateValidity(ob::State* new_goal,
                                                                 const robot_state::RobotState& state,
                                                                 bool verbose) const
 {
-  planning_context_->getOMPLStateSpace()->copyToOMPLState(newGoal, state);
-  return static_cast<const StateValidityChecker*>(si_->getStateValidityChecker().get())->isValid(newGoal, verbose);
+  planning_context_->getOMPLStateSpace()->copyToOMPLState(new_goal, state);
+  return static_cast<const StateValidityChecker*>(si_->getStateValidityChecker().get())->isValid(new_goal, verbose);
 }
 
-bool ompl_interface::ConstrainedGoalSampler::stateValidityCallback(ob::State* newGoal, 
+bool ompl_interface::ConstrainedGoalSampler::stateValidityCallback(ob::State* new_goal, 
                                                                    robot_state::RobotState const* state,
                                                                    const robot_model::JointModelGroup* jmg,
                                                                    const double* jpos,
@@ -76,10 +76,10 @@ bool ompl_interface::ConstrainedGoalSampler::stateValidityCallback(ob::State* ne
   robot_state::RobotState solution_state( *state );
   solution_state.setJointGroupPositions(jmg, jpos);
   solution_state.update();
-  return checkStateValidity(newGoal, solution_state, verbose);
+  return checkStateValidity(new_goal, solution_state, verbose);
 }
 
-bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const ob::GoalLazySamples *gls, ob::State *newGoal)
+bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const ob::GoalLazySamples *gls, ob::State *new_goal)
 {
   //  moveit::Profiler::ScopedBlock sblock("ConstrainedGoalSampler::sampleUsingConstraintSampler");
   
@@ -114,7 +114,7 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
       // makes the constraint sampler also perform a validity callback
       robot_state::GroupStateValidityCallbackFn gsvcf = boost::bind(&ompl_interface::ConstrainedGoalSampler::stateValidityCallback,
                                                                     this,
-                                                                    newGoal, 
+                                                                    new_goal, 
                                                                     _1,  // pointer to state 
                                                                     _2,  // const* joint model group
                                                                     _3,  // double* of joint positions
@@ -126,7 +126,7 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
         work_state_.update();
         if (kinematic_constraint_set_->decide(work_state_, verbose).satisfied)
         {
-          if (checkStateValidity(newGoal, work_state_, verbose))
+          if (checkStateValidity(new_goal, work_state_, verbose))
             return true;
         }
         else
@@ -142,10 +142,10 @@ bool ompl_interface::ConstrainedGoalSampler::sampleUsingConstraintSampler(const 
     }
     else
     {
-      default_sampler_->sampleUniform(newGoal);
-      if (static_cast<const StateValidityChecker*>(si_->getStateValidityChecker().get())->isValid(newGoal, verbose))
+      default_sampler_->sampleUniform(new_goal);
+      if (static_cast<const StateValidityChecker*>(si_->getStateValidityChecker().get())->isValid(new_goal, verbose))
       {
-        planning_context_->getOMPLStateSpace()->copyToRobotState(work_state_, newGoal);
+        planning_context_->getOMPLStateSpace()->copyToRobotState(work_state_, new_goal);
         if (kinematic_constraint_set_->decide(work_state_, verbose).satisfied)
           return true;
       }


### PR DESCRIPTION
In response to this issue: https://github.com/ros-planning/moveit_planners/issues/44

Rather than changing anything in moveit::core::constraint_samplers, simply setting the GroupStateValidityCallbackFn for the `constraint_sampler_` member will make the IKConstraintSampler check the validity of the state and loop over correctly.

To do this, I just added two functions to `ompl_interface::ConstrainedGoalSampler` (a callback and a function for checking validity) which is then used by the member `constraint_sampler::ConstraintSampler`  during IK calls to correctly loop and try randomized seeds.

The other helpful side effect is that this means `ompl_interface::ConstrainedGoalSampler::work_state_` is not modified by the IK call unless it is valid.

This pull request makes the following pull requests redundant:
https://github.com/ros-planning/moveit_planners/pull/46
https://github.com/ros-planning/moveit_core/pull/188
