### PR TITLE
Simplified number of solve() entry points in moveit_planners_ompl

### DIFF
--- a/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -78,14 +78,6 @@ public:
     return context_manager_.getPlannerConfigurations();
   }
 
-  /** @brief Solve the planning problem */
-  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-             const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanResponse &res) const;
-
-  /** @brief Solve the planning problem but give a more detailed response */
-  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-             const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanDetailedResponse &res) const;
-
   ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                   const planning_interface::MotionPlanRequest &req) const;
   ModelBasedPlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,

--- a/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/ompl/ompl_interface/src/ompl_interface.cpp
@@ -128,38 +128,6 @@ void ompl_interface::OMPLInterface::configureContext(const ModelBasedPlanningCon
   context->simplifySolutions(simplify_solutions_);
 }
 
-bool ompl_interface::OMPLInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                          const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanResponse &res) const
-{
-  moveit::tools::Profiler::ScopedStart pslv;
-  moveit::tools::Profiler::ScopedBlock sblock("OMPLInterface:Solve");
-
-  ModelBasedPlanningContextPtr context = getPlanningContext(planning_scene, req);
-  if (context)
-  {
-    context->clear();
-    return context->solve(res);
-  }
-  else
-    return false;
-}
-
-bool ompl_interface::OMPLInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                      const planning_interface::MotionPlanRequest &req, planning_interface::MotionPlanDetailedResponse &res) const
-{
-  moveit::tools::Profiler::ScopedStart pslv;
-  moveit::tools::Profiler::ScopedBlock sblock("OMPLInterface:Solve");
-
-  ModelBasedPlanningContextPtr context = getPlanningContext(planning_scene, req);
-  if (context)
-  {
-    context->clear();
-    return context->solve(res);
-  }
-  else
-    return false;
-}
-
 void ompl_interface::OMPLInterface::loadConstraintApproximations(const std::string &path)
 {
   constraints_library_->loadConstraintApproximations(path);


### PR DESCRIPTION
There are too many entry points in the moveit_planners_ompl pipeline, and anyone who has worked with it knows it is overly complex. This is a small start at cleaning up the API by reducing the number of solve() functions that exist within the pipeline. The two I removed are never used except by a node called `ompl_planner` that no one afaik uses. I believe this node is a relic from arm_nav, etc., before move_group replaced is functionality with a service request. 

On that note, we could probably also just remove the `ompl_planner` because there is just too much code in this what should be simple interface.

Note: the proper way to call `solve` is through a planning context. 

p.s. I think I'm writing these pull requests to myself. Is anyone out there? :-)
