### PR TITLE
fix simplifySolutions(bool) setter

### DIFF
--- a/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -142,7 +142,7 @@ public:
 
   void simplifySolutions(bool flag)
   {
-    simplify_solutions_ = true;
+    simplify_solutions_ = flag;
   }
 
   /** @brief Look up param server 'constraint_approximations' and use its value as the path to save constraint approximations to */


### PR DESCRIPTION
The method simplifySolutions(bool) always set the "simplify_solutions_" member to true and the input variable "flag" was ignored. This setting is exposed to the user by dynamic reconfigure. By now, this flag in the dynamic reconfigure interface is changing nothing because of the above mentioned problem.
The method is fixed by setting the "simplify_solutions_" member to the value of the input variable "flag".
