### PR TITLE
fixing internal storing of config settings

### DIFF
--- a/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -69,6 +69,7 @@ public:
     std::string ompl_ns = ns.empty() ? "ompl" : ns + "/ompl";
     dynamic_reconfigure_server_.reset(new dynamic_reconfigure::Server<OMPLDynamicReconfigureConfig>(ros::NodeHandle(nh_, ompl_ns)));
     dynamic_reconfigure_server_->setCallback(boost::bind(&OMPLPlannerManager::dynamicReconfigureCallback, this, _1, _2));
+    config_settings_ = ompl_interface_->getPlannerConfigurations();
     return true;
   }
 


### PR DESCRIPTION
config_settings_ was never being set so getPlannerConfigurations always returns an empty map. 
