### PR TITLE
Fixed include directory order to make ros package shadowing work.

### DIFF
--- a/ompl/CMakeLists.txt
+++ b/ompl/CMakeLists.txt
@@ -36,8 +36,8 @@ include_directories(SYSTEM
                     ${Boost_INCLUDE_DIRS})
 
 include_directories(ompl_interface/include
-                    ${OMPL_INCLUDE_DIRS}
-                    ${catkin_INCLUDE_DIRS})
+                    ${catkin_INCLUDE_DIRS}
+                    ${OMPL_INCLUDE_DIRS})
 
 link_directories(${OMPL_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})


### PR DESCRIPTION
Before this change, the `-I/opt/ros/indigo/include` compile option from `${OMPL_INCLUDE_DIRS}` would come before all of the `-I/home/hersh/my-ws/src/myproject/include` options defined in `${catkin_INCLUDE_DIRS}`.  That is a problem when I have a project in my workspace which is also installed in /opt/ros/indigo and which has header files with changes.  Then the old version builds ompl_interface with the old version of the include files and my other code with the new version, and the results are not good when they get linked together.

After switching the lines, /opt/ros/indigo/include is correctly way at the end, after all of my workspace's include dirs, and only the correct version of the include file is used.
