### PR TITLE
Allow compiling against OMPL with C++11 support.

### DIFF
--- a/ompl/ompl_interface/include/moveit/ompl_interface/detail/same_shared_ptr.hpp
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/detail/same_shared_ptr.hpp
@@ -1,0 +1,63 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2016 Delft Robotics.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the copyright holder nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Maarten de Vries */
+
+#include <boost/shared_ptr.hpp>
+
+#if __cplusplus >= 201103L
+#  include <memory>
+#endif
+
+namespace ompl_interface
+{
+
+template<typename T, typename OtherPtrType>
+struct same_shared_ptr;
+
+#if __cplusplus >= 201103L
+template<typename T, typename Wrapped>
+struct same_shared_ptr<T, std::shared_ptr<Wrapped> >
+{
+  typedef std::shared_ptr<T> type;
+};
+#endif
+
+template<typename T, typename Wrapped>
+struct same_shared_ptr<T, boost::shared_ptr<Wrapped> >
+{
+  typedef boost::shared_ptr<T> type;
+};
+
+}

--- a/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
+++ b/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/model_based_state_space.h
@@ -42,6 +42,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <moveit/constraint_samplers/constraint_sampler.h>
+#include "../detail/same_shared_ptr.hpp"
 
 namespace ompl_interface
 {
@@ -277,7 +278,7 @@ protected:
 
 };
 
-typedef boost::shared_ptr<ModelBasedStateSpace> ModelBasedStateSpacePtr;
+typedef same_shared_ptr<ModelBasedStateSpace, ompl::base::StateSpacePtr>::type ModelBasedStateSpacePtr;
 
 }
 


### PR DESCRIPTION
The head of OMPL requires C++11 and unconditionally ditched `boost::shared_ptr` for `std::shared_ptr` [1]. That leads to an incompatibility in the moveit ompl plugin.

This PR adds a template `same_shared_ptr<T, OtherPtr>` which has a `type` typedef using the correct `shared_ptr` (taken from OtherPtr). Preprocessor checks prevent the include of `<memory>` and the mention of `std::shared_ptr` if C++11 support is not available.

I only changed the type of `shared_ptr` where it was required by OMPL, which was only one place.

[1] https://bitbucket.org/ompl/ompl/commits/d47925099e2307e50f7420eedad604452dcc297a
