### PR TITLE
Require C++11 support

### DIFF
--- a/ompl/CMakeLists.txt
+++ b/ompl/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(moveit_planners_ompl)
 
+# C++ 11 required for OMPL
+add_compile_options(-std=c++11)
+
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()


### PR DESCRIPTION
The Kinetic version of OMPL (1.2.0) [requires C++11 support](https://groups.google.com/forum/#!topic/moveit-users/sEqP6iXOrVc). This turns it on for the new kinetic branch. Required for https://github.com/ros-planning/moveit_ros/issues/695
